### PR TITLE
added feacture for toggle the user status admin only route also a min…

### DIFF
--- a/backend/src/controllers/admin/toggleUserStatusController.js
+++ b/backend/src/controllers/admin/toggleUserStatusController.js
@@ -1,0 +1,44 @@
+import selectUserByIdAdminOnlyService from '../../services/admin/selectUserByIdAdminOnlyService.js';
+import toggleUserStatusService from '../../services/admin/toggleUserStatusService.js';
+import generateErrorsUtils from '../../utils/generateErrorsUtils.js';
+
+const toggleUserStatusController = async (req, res, next) => {
+  try {
+    const { id } = req.params;
+
+    const user = await selectUserByIdAdminOnlyService(id);
+
+    // console.log(req.user.id, typeof req.user.id);
+    // console.log('el id', id, typeof id);
+
+    if (parseInt(id) === req.user.id) {
+      throw generateErrorsUtils(
+        'Cuidado estas intentando cambiar tu propio estado'
+      );
+    }
+
+    const newStatus = !user.enable;
+
+    await toggleUserStatusService(newStatus, id);
+
+    const response = {
+      id: id,
+      enable: newStatus,
+    };
+
+    // console.log('id', id, typeof id);
+    // console.log('enable', newStatus, typeof newStatus);
+
+    res.send({
+      status: 'ok',
+      message: `Usuario ${newStatus ? 'Habilitado' : 'Deshabilitado'} correctamente`,
+      data: {
+        response,
+      },
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
+export default toggleUserStatusController;

--- a/backend/src/db/seedDb.js
+++ b/backend/src/db/seedDb.js
@@ -93,6 +93,9 @@ const seedDB = async () => {
     await pool.query('DELETE FROM fav');
     await pool.query('DELETE FROM users');
 
+    // Reiniciar el auto-increment
+    await pool.query('ALTER TABLE users AUTO_INCREMENT = 1');
+
     // Insertar usuarios
     const users = generateUsers(20);
     await pool.query(

--- a/backend/src/middlewares/authAdmin.js
+++ b/backend/src/middlewares/authAdmin.js
@@ -28,7 +28,7 @@ const authAdmin = (req, res, next) => {
       throw generateErrorsUtils('No tienes permisos de administrador', 403);
     }
 
-    console.log('pase el middleware de authadmin');
+    // console.log('pase el middleware de authadmin');
     next();
   } catch (error) {
     next(error);

--- a/backend/src/routes/adminRouter.js
+++ b/backend/src/routes/adminRouter.js
@@ -2,8 +2,18 @@ import express from 'express';
 import authUser from '../middlewares/authUser.js';
 import authAdmin from '../middlewares/authAdmin.js';
 import listAllUsersController from '../controllers/admin/listAllUsersController.js';
+import toggleUserStatusController from '../controllers/admin/toggleUserStatusController.js';
 
 //Creamos un router.
 export const adminRouter = express.Router();
 
+// ruta de administrador para listar todos los usuarios que actualmente hay en la base de datos
 adminRouter.get('/admin/users', authUser, authAdmin, listAllUsersController);
+
+// ruta de administrador para toglear le estado de los usuarios de enable 1 a 0 y viceversa
+adminRouter.patch(
+  '/admin/:id/status',
+  authUser,
+  authAdmin,
+  toggleUserStatusController
+);

--- a/backend/src/services/admin/selectUserByIdAdminOnlyService.js
+++ b/backend/src/services/admin/selectUserByIdAdminOnlyService.js
@@ -1,0 +1,23 @@
+import getPool from '../../db/getPool.js';
+import generateErrorsUtils from '../../utils/generateErrorsUtils.js';
+
+const selectUserByIdAdminOnlyService = async (id) => {
+  const pool = await getPool();
+
+  const [user] = await pool.query(
+    `
+        SELECT * 
+        FROM users
+        WHERE id = ?
+        `,
+    [id]
+  );
+
+  if (!user.length) {
+    throw generateErrorsUtils('El usuario no existe', 404);
+  }
+
+  return user[0];
+};
+
+export default selectUserByIdAdminOnlyService;

--- a/backend/src/services/admin/toggleUserStatusService.js
+++ b/backend/src/services/admin/toggleUserStatusService.js
@@ -1,0 +1,21 @@
+import getPool from '../../db/getPool.js';
+import generateErrorsUtils from '../../utils/generateErrorsUtils.js';
+
+const toggleUserStatusService = async (newStatus, id) => {
+  const pool = await getPool();
+
+  const afectedRows = await pool.query(
+    `
+        UPDATE users
+        SET enable = ?
+        WHERE id = ?
+        `,
+    [newStatus, id]
+  );
+
+  if (!afectedRows) {
+    throw generateErrorsUtils('No se actualizo correctamente el usuario', 304);
+  }
+};
+
+export default toggleUserStatusService;


### PR DESCRIPTION
…or change to seedDb script
Modificado el seedDb para que funcione cuando la base de datos ya tenga cosas dentro
Agregada la ruta para habilitar y deshabilitar usuarios al router de admin (requiere que el usuario este logeado, y que sea admiin)
Creado el servicio selectUserByIdAdminOnly, regresa toda la info que hay de un usuario en la base de datos (cuidado solo debe ser usado por admins)
Creado el servicio toggleUserStatusService togglea el enable de un usuario, regresa el id y el status
Creado el controlador toggleUserStatusController que se usa en la nueva ruta del router de admin
Testeado en postman (admin no puede auto des habilitarse, usuario logeado que no es admin no puede entrar a la ruta,)